### PR TITLE
(fix) index view 내의 template 이름 수정

### DIFF
--- a/django/payments/views.py
+++ b/django/payments/views.py
@@ -5,7 +5,7 @@ import requests, json, base64, time
 def index(request):
   return render(
     request,
-    'payments/window.html',
+    'payments/index.html',
   )
 
 def success(request):


### PR DESCRIPTION
'window.html' 참조시 참조 에러 발생하여 'index.html'로 수정이 필요합니다 🙂