### PR TITLE
:bug: fix(vue-checkout): PaymentWidget 임포트 문제 해결

### DIFF
--- a/vue/src/views/CheckoutView.vue
+++ b/vue/src/views/CheckoutView.vue
@@ -74,7 +74,7 @@ export default {
   async mounted() {
     // ------  결제위젯 초기화 ------
     // @docs https://docs.tosspayments.com/reference/widget-sdk#sdk-설치-및-초기화
-    this.paymentWidget = PaymentWidget(this.clientKey, ANONYMOUS);
+    this.paymentWidget = await loadPaymentWidget(this.clientKey, ANONYMOUS);
 
     // ------  결제 UI 렌더링 ------
     // @docs https://docs.tosspayments.com/reference/widget-sdk#renderpaymentmethods선택자-결제-금액-옵션


### PR DESCRIPTION
[관련 Discord 인입 QA](https://discord.com/channels/864296203746803753/1201344396457676830)

### 개요
위 QA에서 Vue 샘플 소스의 SDK import구문의 잘못된 사용(loadPaymentWidget 누락) 으로 인한 `'PaymentWidget' is not defined` 문제를 해결합니다.

### 변경 사항
기존 paymentWidget 변수를 선언하는 부분에서 PaymentWidget를 바로 이용하지 않고 loadPaymentWidget를 이용하도록 코드를 수정했습니다. ([참고](https://docs.tosspayments.com/reference/widget-sdk#sdk-%EC%84%A4%EC%B9%98-%EB%B0%8F-%EC%B4%88%EA%B8%B0%ED%99%94))