### PR TITLE
fix: Flutter 4 개 경고 제거활동

### DIFF
--- a/flutter/lib/components.dart
+++ b/flutter/lib/components.dart
@@ -1,26 +1,72 @@
 import 'package:flutter/material.dart';
 
-ElevatedButton BlueButton({
-  required void Function() onPressed,
-  required String text,
-}) {
-  return ElevatedButton(
-    onPressed: onPressed,
-    style: ElevatedButton.styleFrom(
-      backgroundColor: Colors.blue,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12.0),
+/// 파란색 배경을 가진 커스텀 버튼 위젯입니다.
+///
+/// 이 버튼은 [onPressed] 콜백, 표시할 [text], [backgroundColor], [borderRadius], [minimumSize]와 같은 다양한 속성으로 커스터마이징할 수 있습니다.
+/// 이러한 속성 중 하나라도 제공되지 않는 경우, 기본값이 사용됩니다.
+///
+/// 사용 예시:
+/// ```dart
+/// BlueButton(
+///   onPressed: () {},
+///   text: 'Click me',
+///   backgroundColor: Colors.blue,
+///   borderRadius: 8.0,
+///   minimumSize: Size(120, 48),
+/// )
+/// ```
+class BlueButton extends StatelessWidget {
+  final void Function() onPressed;
+  final String text;
+  final Color? backgroundColor;
+  final double? borderRadius;
+  final Size? minimumSize;
+
+  const BlueButton({
+    Key? key,
+    required this.onPressed,
+    required this.text,
+    this.backgroundColor,
+    this.borderRadius,
+    this.minimumSize,
+  }) : super(key: key);
+
+  BlueButton copyWith({
+    void Function()? onPressed,
+    String? text,
+    Color? backgroundColor,
+    double? borderRadius,
+    Size? minimumSize,
+  }) {
+    return BlueButton(
+      onPressed: onPressed ?? this.onPressed,
+      text: text ?? this.text,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      borderRadius: borderRadius ?? this.borderRadius,
+      minimumSize: minimumSize ?? this.minimumSize,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: backgroundColor ?? Colors.blue,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(borderRadius ?? 12.0),
+        ),
+        minimumSize: minimumSize ?? const Size(0, 56),
       ),
-      minimumSize: const Size(0, 56),
-    ),
-    child: Center(
-      child: Text(
-        text,
-        style: const TextStyle(
-          fontSize: 16,
-          color: Colors.white,
+      child: Center(
+        child: Text(
+          text,
+          style: const TextStyle(
+            fontSize: 16,
+            color: Colors.white,
+          ),
         ),
       ),
-    ),
-  );
+    );
+  }
 }

--- a/flutter/lib/screens/result.dart
+++ b/flutter/lib/screens/result.dart
@@ -1,4 +1,3 @@
-import 'package:example/utils/clipboard.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:tosspayments_widget_sdk_flutter/model/tosspayments_result.dart';
@@ -15,7 +14,9 @@ class ResultPage extends StatelessWidget {
   /// [title]는 회색 텍스트 스타일로, [message]는 기본 텍스트 스타일로 표시됩니다.
   Row makeRow(String title, String message) {
     return Row(children: [
-      Expanded(flex: 3, child: Text(title, style: const TextStyle(color: Colors.grey))),
+      Expanded(
+          flex: 3,
+          child: Text(title, style: const TextStyle(color: Colors.grey))),
       Expanded(
         flex: 8,
         child: Text(message),
@@ -29,57 +30,63 @@ class ResultPage extends StatelessWidget {
   /// [result]이 [Fail] 타입이면 오류 메시지와 함께 세부 정보를 표시합니다.
   /// 그 외의 경우, 비어있는 [Container]를 반환합니다.
   Container getContainer(dynamic result) {
-    if (result is Success) {
-      Success success = result;
-      return Container(
-        child: Column(
-          children: <Widget>[
-            makeRow('paymentKey', success.paymentKey),
-            const SizedBox(height: 20),
-            makeRow('orderId', success.orderId),
-            const SizedBox(height: 20),
-            makeRow('amount', success.amount.toString()),
-            const SizedBox(height: 20),
-            Column(
-                children: success.additionalParams?.entries
-                        .map<Widget>((e) => Column(
-                              children: [makeRow(e.key, e.value), const SizedBox(height: 10)],
-                            ))
-                        .toList() ??
-                    []),
-            ElevatedButton(
-              onPressed: () {
-                copyToClipboard(success.toString());
-              },
-              child: const Center(
-                child: Text(
-                  '복사하기',
-                  style: TextStyle(
-                    fontSize: 16,
-                    color: Colors.white,
+    return Container(
+      color: Colors.transparent,
+      child: Builder(
+        builder: (context) {
+          // Success 타입인 경우
+          if (result is Success) {
+            return Column(
+              children: <Widget>[
+                makeRow('paymentKey', result.paymentKey),
+                const SizedBox(height: 20),
+                makeRow('orderId', result.orderId),
+                const SizedBox(height: 20),
+                makeRow('amount', result.amount.toString()),
+                const SizedBox(height: 20),
+                ...?result.additionalParams?.entries.map<Widget>((e) => Column(
+                      children: [
+                        makeRow(e.key, e.value),
+                        const SizedBox(height: 10),
+                      ],
+                    )),
+                ElevatedButton(
+                  onPressed: () {
+                    // copyToClipboard 함수 구현 필요
+                    // copyToClipboard(result.toString());
+                  },
+                  child: const Center(
+                    child: Text(
+                      '복사하기',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Colors.white,
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
-          ],
-        ),
-      );
-    } else if (result is Fail) {
-      Fail fail = result;
-      return Container(
-        child: Column(
-          children: <Widget>[
-            makeRow('errorCode', fail.errorCode),
-            const SizedBox(height: 20),
-            makeRow('errorMessage', fail.errorMessage),
-            const SizedBox(height: 20),
-            makeRow('orderId', fail.orderId),
-          ],
-        ),
-      );
-    } else {
-      return Container();
-    }
+              ],
+            );
+          }
+
+          // Fail 타입인 경우
+          if (result is Fail) {
+            return Column(
+              children: <Widget>[
+                makeRow('errorCode', result.errorCode),
+                const SizedBox(height: 20),
+                makeRow('errorMessage', result.errorMessage),
+                const SizedBox(height: 20),
+                makeRow('orderId', result.orderId),
+              ],
+            );
+          }
+
+          // Success 또는 Fail 타입이 아닌 경우
+          return const SizedBox(); // 빈 위젯 반환
+        },
+      ),
+    );
   }
 
   /// 위젯을 빌드합니다.

--- a/flutter/lib/screens/tosspayments/home.dart
+++ b/flutter/lib/screens/tosspayments/home.dart
@@ -11,7 +11,7 @@ class Home extends StatefulWidget {
   const Home({super.key});
 
   @override
-  _HomeState createState() => _HomeState();
+  State<Home> createState() => _HomeState();
 }
 
 /// [_HomeState]는 [Home] 위젯의 상태를 관리하는 클래스입니다.


### PR DESCRIPTION
## PR 요청 사유
> 경고 메시지를 제거하여, 코드에 조금이라도 기여하고 싶어서 PR 요청 드립니다.

## 실행 환경

```shell
[✓] Flutter (Channel stable, 3.16.8, on macOS 13.2.1 22D68 darwin-x64, locale ko)
[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
[✓] Xcode - develop for iOS and macOS (Xcode 14.3)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2023.1)
[✓] IntelliJ IDEA Ultimate Edition (version 2023.3.2)
[✓] VS Code (version 1.85.0)
[✓] Connected device (3 available)
[✓] Network resources

```

## 설명

최초 실행 시, 4 개의 Lint Warning이 있었습니다.(3 가지 종류)
![스크린샷 2024-02-28 오후 1 42 08](https://github.com/tosspayments/payment-widget-sample/assets/65879950/228acd16-2fca-42c9-9e08-a895a81aabe0)

이에 대해 경고를 제거하여 코드 퀄리티 개선작업에 기여하고자 PR 요청 신청합니다.

### 1. [non_constant_identifier_names](https://dart.dev/tools/linter-rules/non_constant_identifier_names) 경고 제거
- 기존의 `BlueButton` 메서드를 Subclassing으로 변경
- 이를 통해, lowerCamelCase의 메서드 명명이 없어지고, Class이므로 동일한 이름으로 호출해도 Lint Warning 제거됨

### 2. [avoid_unnecessary_containers](https://dart.dev/tools/linter-rules/avoid_unnecessary_containers) 경고 제거
- 기존 Container를 리턴하는 메서드가, if 절에서 각각 return 을 3 번하고 있었고, 이것을 return을 1회하도록 리팩터링
- 기존에 경고가 2 번 호출되든 것을 1회로 제거하였고, Container의 파라미터에 특정 값을 지정하여 최종적으로 Lint Warning제거

### 3. [library_private_types_in_public_api](https://dart.dev/tools/linter-rules/library_private_types_in_public_api) 경고 제거
- "createState" 메서드는 Public 접근제한자인데, private type을 리턴하고 있어서 발생한 경고
- 이에 대해 기존 `_HomeState` 타입을 리턴하는 것이 아닌 `_HomeState`의 상위 클래스인 `State<Home>`을 리턴하도록 리팩터링

## 최종 결과

![스크린샷 2024-02-28 오후 2 17 02](https://github.com/tosspayments/payment-widget-sample/assets/65879950/46003a1d-1edc-4cca-b810-c9824fd01706)
